### PR TITLE
KeyError in publishCameraState when camera is not ready on PTZ camera

### DIFF
--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -36,8 +36,9 @@ class StateThread(threading.Thread):
         '''Using Axis VAPIX protocol, described in the comments at the top of
         this file, is used to query the state of the camera'''
         queryParams = { 'query':'position' }
+        conn = httplib.HTTPConnection(self.axis.hostname)
+
         try:
-            conn = httplib.HTTPConnection(self.axis.hostname)
             conn.request("GET", "/axis-cgi/com/ptz.cgi?%s" % 
                                                 urllib.urlencode(queryParams))
             response = conn.getresponse()
@@ -66,8 +67,6 @@ class StateThread(threading.Thread):
             rospy.logwarn(exception_error_str)
 
             self.cameraPosition = None
-        finally:
-            conn.close()
    
     def publishCameraState(self):
         '''Publish camera state to a ROS message'''


### PR DESCRIPTION
On Axis P5532-E, axis_camera.axis_ptz.publishCameraState will launch a KeyError if the ROS driver is started too soon after the camera has booted. I did not fully investigated it but, for some reason, even though the GET request returns a response, it does not have the 'zoom' field. Therefore, when publishCameraState tries to access self.cameraPosition['zoom'], a KeyError is raised, causing the Thread polling the telemetry to crash. I added a catch KeyError in publishCameraState. 