### PR TITLE
add support for quad video

### DIFF
--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -38,7 +38,7 @@ class StreamThread(threading.Thread):
 
         # support for Axis F34 multicamera switch
         if (self.axis.camera != 0):
-            self.url += "&camera=%d" % self.axis.camera
+            self.url += "&camera=%s" % str(self.axis.camera)
 
         rospy.logdebug('opening ' + str(self.axis))
 


### PR DESCRIPTION
removed the requirement of camera to be an integer thus allowing 'quad' camera view to be used.