### PR TITLE
Improve F34 and F44 support.

### DIFF
--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -1,17 +1,18 @@
 <launch>
   <arg name="camera_name" default="axis" />
-  <arg name="hostname" default="192.168.1.13" />
+  <arg name="hostname" default="192.168.0.90" />
   <arg name="enable_theora" default="0" />
   <arg name="enable_ptz" default="0" />
   <arg name="enable_ptz_teleop" default="0" />
   <arg name="width" default="640" />
   <arg name="height" default="480" />
+  <arg name="camera" default="1" />
 
   <group ns="$(arg camera_name)">
     <param name="hostname" value="$(arg hostname)" />
     <param name="width" value="$(arg width)" />
     <param name="height" value="$(arg height)" />
-    <param name="camera" value="0" />
+    <param name="camera" value="$(arg camera)" />
     <node pkg="axis_camera" type="axis.py" name="axis" />
     <node pkg="axis_camera" type="axis_ptz.py" name="axis_ptz" if="$(arg enable_ptz)" />
 

--- a/tests/view_axis.launch
+++ b/tests/view_axis.launch
@@ -11,7 +11,8 @@
                               (default: use generic axis_camera calibration)
 -->
 <launch>
-  <arg name="camera" default="axis_camera" />
+  <arg name="camera_name" default="axis" />
+  <arg name="camera" default="1" />
   <arg name="hostname" default="192.168.0.90" />
   <arg name="username" default="root" />
   <arg name="password" />
@@ -24,7 +25,8 @@
       <param name="hostname" value="$(arg hostname)" />
       <param name="username" value="$(arg username)" />
       <param name="password" value="$(arg password)" />
-      <param name="frame_id" value="$(arg camera)" />
+      <param name="frame_id" value="$(arg camera_name)" />
+      <param name="camera"   value="$(arg camera)" />
       <param name="camera_info_url" value="$(arg camera_info_url)" />
     </node>
 


### PR DESCRIPTION
Improve support for the F34 multi-camera controller by adding default values for the camera index (1-4). Change the camera arg in view_axis to camera_name, change its default IP address to better-match with the main axis.launch file