### PR TITLE
Explicitly use Python3 in shebang for teleop nodes

### DIFF
--- a/nodes/teleop.py
+++ b/nodes/teleop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from sensor_msgs.msg import Joy

--- a/nodes/teleop_speed_control.py
+++ b/nodes/teleop_speed_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from sensor_msgs.msg import Joy

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
It appears that `catkin_python_install()` is not working correctly in terms of selecting Python3 at runtime to run the `teleop.py` and `teleop_speed_control.py`, when the package is installed from deb/binary or with `catkin_make install`. This can be reproduced on a Noetic machine (e.g. my laptop and 2 Jackals) with:

`sudo apt-get update`
`sudo apt-get install ros-noetic-axis-camera`
`rosrun axis_camera teleop.py`

OR

`cd ~/catkin_ws/src`
`git clone -b noetic-devel https://github.com/ros-drivers/axis_camera.git`
`cd ..`
`catkin_make install`
`source install/setup.bash`
`rosrun axis_camera teleop.py`

In both instances, ROS will complain with `/opt/ros/noetic/bin/rosrun: /home/jyang/projects/test_ws/install/lib/axis_camera/teleop.py: /usr/bin/python: bad interpreter: No such file or directory`

To fix this, we can just specify Python3 in the shebang.

This PR also removes the shebang in `setup.py`, since it is not necessary, as per:
- http://docs.ros.org/en/jade/api/catkin/html/howto/format2/installing_python.html
- https://stackoverflow.com/questions/35701131/why-does-setup-py-usually-not-have-a-shebang-line#:~:text=setup.py%20is%20going%20to,with%20the%20interpreter%20before%20it.