### PR TITLE
Improve auth support, add Q62 Series feature support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change history
 ==============
 
+Forthcoming
+-----------
+* Merge pull request `#73 <https://github.com/ros-drivers/axis_camera/issues/73>`_ from jhiggins-cpr/noetic-devel
+  Add frames-per-second (fps) as a configurable option
+* Reverting package change as it happens automatically
+* Add frames-per-second (fps) as a configurable option
+* Contributors: Jason Higgins, Tony Baltovski
+
 0.4.2 (2022-07-29)
 ------------------
 * Explicitly use Python3 in shebang for teleop nodes; remove unnecessary shebang in setup.py (`#72 <https://github.com/ros-drivers/axis_camera/issues/72>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change history
 ==============
 
+Forthcoming
+-----------
+* Explicitly use Python3 in shebang for teleop nodes; remove unnecessary shebang in setup.py (`#72 <https://github.com/ros-drivers/axis_camera/issues/72>`_)
+* Contributors: Joey Yang
+
 0.4.1 (2022-06-16)
 ------------------
 * Fix the #! lines to use python3, decode the utf8 bytes into a string to suppress a warning when parsing the camera position

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change history
 ==============
 
-Forthcoming
------------
+0.4.3 (2022-08-22)
+------------------
 * Merge pull request `#73 <https://github.com/ros-drivers/axis_camera/issues/73>`_ from jhiggins-cpr/noetic-devel
   Add frames-per-second (fps) as a configurable option
 * Reverting package change as it happens automatically

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change history
 ==============
 
-Forthcoming
------------
+0.4.2 (2022-07-29)
+------------------
 * Explicitly use Python3 in shebang for teleop nodes; remove unnecessary shebang in setup.py (`#72 <https://github.com/ros-drivers/axis_camera/issues/72>`_)
 * Contributors: Joey Yang
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,46 @@
 Change history
 ==============
 
+Forthcoming
+-----------
+* upgraded cmakelist and package.xml, and setup.py for noetic (`#70 <https://github.com/ros-drivers/axis_camera/issues/70>`_)
+* Update the python files to be python-3 compliant.  Fix some bugs in the image data parsing needed as part of this update
+* Merge pull request `#55 <https://github.com/ros-drivers/axis_camera/issues/55>`_ from sgemme-csa/master
+  KeyError in publishCameraState when camera is not ready on PTZ camera
+* Merge branch 'master' of github.com:ros-drivers/axis_camera
+* Expose the height & width parameters as arguments in the launch file
+* Merge pull request `#56 <https://github.com/ros-drivers/axis_camera/issues/56>`_ from jeff-o/patch-1
+  Update axis.launch
+* Revert "Fix up the main scripts to be python-3 compliant"
+  This reverts commit 569e4b22415edee653914fa387a689d2e85e2879.
+* Fix up the main scripts to be python-3 compliant
+* Merge branch 'master' of github.com:ros-drivers/axis_camera
+* Merge pull request `#58 <https://github.com/ros-drivers/axis_camera/issues/58>`_ from luishowell/master
+  add support for quad video
+* Merge pull request `#61 <https://github.com/ros-drivers/axis_camera/issues/61>`_ from cclauss/patch-1
+  Fix Python 3 syntax error
+* Remove the html_static directory from conf.py; it doesn't exist anyway and is just creating a warning that's causing Jenkins to see the build as unstable
+* Fix Python 3 syntax error
+  `#52 <https://github.com/ros-drivers/axis_camera/issues/52>`_ again
+* Remove the :: leftover from the .rst
+* Copy the README contents to the .md so they show up on the github main page
+* Update the maintainer now that Clearpath is officially maintaining this package again
+* Merge pull request `#54 <https://github.com/ros-drivers/axis_camera/issues/54>`_ from k-okada/add_travis
+  update travis.yml
+* update travis.yml
+* add support for quad video
+* Update axis.launch
+  Adds the "camera" param to the launch file. Helps launch the driver cleanly when used with other drivers that also use "camera" as a param name.
+* No need to close connection as it will get garbage collected
+* Merge remote-tracking branch 'csa/develop' into github-master
+* Adjusting error message on KeyError
+* Merge remote-tracking branch 'github/master' into develop
+* Merge branch 'develop' of git+ssh://liberty/data/git/ros/axis_camera into develop
+* Fixing camera telemetry where accessing its telemetry before a certain time after startup would causes a KeyError because the fields in the response were not present. Now catching the KeyError exception to fix the problem.
+* Fixing camera telemetry where accessing its telemetr before a certain time after startup would cause a KeyError because the fiels in the response were not present, now catchin the KeyError exception to fix the problem
+* Fixing connection problem which was causing the telemetry to stall
+* Contributors: Chris I-B, Christian Clauss, Howell, Jeff Schmidt, Kei Okada, Sebastien Gemme, jmastrangelo-cpr
+
 0.3.0 (2018-05-25)
 ------------------
 * Merge pull request `#49 <https://github.com/ros-drivers/axis_camera/issues/49>`_ from rossctaylor/feature/support_for_f34

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change history
 ==============
 
+Forthcoming
+-----------
+* Fix the #! lines to use python3, decode the utf8 bytes into a string to suppress a warning when parsing the camera position
+* Contributors: Chris Iverach-Brereton
+
 0.4.0 (2021-11-29)
 ------------------
 * upgraded cmakelist and package.xml, and setup.py for noetic (`#70 <https://github.com/ros-drivers/axis_camera/issues/70>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change history
 ==============
 
-Forthcoming
------------
+0.4.0 (2021-11-29)
+------------------
 * upgraded cmakelist and package.xml, and setup.py for noetic (`#70 <https://github.com/ros-drivers/axis_camera/issues/70>`_)
 * Update the python files to be python-3 compliant.  Fix some bugs in the image data parsing needed as part of this update
 * Merge pull request `#55 <https://github.com/ros-drivers/axis_camera/issues/55>`_ from sgemme-csa/master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change history
 ==============
 
-Forthcoming
------------
+0.4.1 (2022-06-16)
+------------------
 * Fix the #! lines to use python3, decode the utf8 bytes into a string to suppress a warning when parsing the camera position
 * Contributors: Chris Iverach-Brereton
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(axis_camera)
 
 find_package(catkin REQUIRED
@@ -17,7 +17,7 @@ generate_dynamic_reconfigure_options(cfg/PTZ.cfg)
 
 catkin_package()
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   nodes/axis.py
   nodes/axis_ptz.py
   nodes/publish_axis_tf.py

--- a/README.md
+++ b/README.md
@@ -21,3 +21,126 @@ There is no released code API.
 
 Each official release is tagged in the repository. The
 [change history](https://github.com/clearpathrobotics/axis_camera/blob/master/CHANGELOG.rst) describes every version.
+
+
+Supported Cameras
+------------------
+
+The following is a list of cameras that have been tested with this driver and are known to work.  Other cameras may
+also be usable, but have not been tested by the developers/maintainers of this package.
+
+- [M30 Series](https://www.axis.com/en-ca/products/axis-m30-series)
+- [M42 Series](https://www.axis.com/en-ca/products/axis-m42-series)
+- [Q62 Series](https://www.axis.com/en-ca/products/axis-q62-series)
+- [F Series](https://www.axis.com/en-ca/products/axis-f-series)
+
+
+Camera Preparation
+-------------------
+
+Before using the ROS driver you should ensure your camera is properly connected to the PC and powered as-per the
+manufacturer's specifications.
+
+We recommend configuring the camera to use a static IP address on your robot's internal wired LAN, rather than DHCP.
+Because the driver addresses the camera by hostname or IP address it's easier if the address is constant.
+
+Some cameras work best if you also enable `Anonymous Viewing` and `Anonymous PTZ Commands`, if supported.  This removes
+the need to authenticate to the camera to consume video data or control the PTZ position.
+
+
+Usage
+------
+
+Once the camera is configured, simply launch the driver:
+
+```bash
+roslaunch axis_camera axis.launch hostname:=192.168.0.90 username:=root password:=password
+```
+
+If your camera supports PTZ control, you can enable it with
+
+```bash
+roslaunch axis_camera axis.launch hostname:=192.168.0.90 username:=root password:=password enable_ptz:=true
+```
+
+In the case of the F Series cameras, multiple cameras can be connected to a single controller box.  In this case, launch
+the driver once for each physical camera, specifying the camera name & ID number.  The ID number corresponds to the
+physical port in the e.g. F34 controller (1-4).
+
+```bash
+roslaunch axis_camera axis.launch hostname:=192.168.0.90 username:=root password:=password camera_name:=front_camera camera:=1
+
+roslaunch axis_camera axis.launch hostname:=192.168.0.90 username:=root password:=password camera_name:=rear_camera camera:=2
+```
+
+The Q62 Series cameras also feature a night-vision mode (adds and IR illuminator and disables the IR filter), a lens
+wiper, and a defogger in addition to the normal PTZ control.  To enable all of this camera's supported features, use
+
+```bash
+roslaunch axis_camera axis.launch hostname:=192.168.0.90 username:=root password:=password enable_ptz:=true enable_ir:=true enable_defog:=true enable_wiper:=true
+```
+
+Topics and Services
+--------------------
+
+The camera's main image data is published on `/camera_name/image_raw` as a `sensor_msgs/Image` message.
+
+If the `enable_theora` argument is `true` then a the compressed camera data is also available on `/camera_name/image_raw_out`.
+
+PTZ control (if enabled) uses the `axis_camera/Axis.msg` type:
+
+```
+float32 pan
+float32 tilt
+float32 zoom
+float32 focus
+float32 brightness
+float32 iris
+bool autofocus
+```
+
+To write to the camera, use
+
+```bash
+rostopic pub /camera_name/cmd axis_camera/Axis "{pan: 45.0, tilt: 20.0, zoom: 1000.0, focus: 0.0, brightness: 1.0, iris: 1.0, autofocus: true}" -1
+```
+
+All writable camera properties are set simultaneously.  It is recommended to read the camera's current state from
+`/camera_name/state`, copy the `focus`, `autofocus`, `brightness`, and `iris` parameters, and then set the `pan`,
+`tilt` and `zoom` fields as desired.
+
+`pan` and `tilt` are expressed in degrees (for ease of use with Axis' REST API) with positive tilt being upwards and
+positive pan being anticockwise.
+
+`zoom` is a value from 1 to 10000, with higher numbers indicating a narrower field of view.
+
+The Q62 Series' IR mode can be toggled by running
+
+```bash
+rosservice call /camera_name/set_ir_on "data: true"  # or "data: false"
+```
+
+When IR mode is on the IR illuminator will be turned on and the IR filter turned off.  The current state of the IR
+mode can be read from `/camera_name/ir_on` as a `std_msgs/Bool`.
+
+To enable the defogger, run
+
+```bash
+rosservice call /camera_name/set_defog_on "data: true"  # or "data: false"
+```
+
+The current state of the defogger can be read from `/camera_name/defog_on` as a `std_msgs/Bool`.
+
+To start the lens wiper, run
+
+```bash
+rosservice call /camera_name/set_wiper_on "data: true"
+```
+
+The wiper will run for 10s and stop automatically.  You can stop the wiper early by running
+
+```bash
+rosservice call /camera_name/set_wiper_on "data: false"
+```
+
+The current state of the wiper can be read from `/camera_name/wiper_on` as a `std_msgs/Bool`.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ Supported Cameras
 The following is a list of cameras that have been tested with this driver and are known to work.  Other cameras may
 also be usable, but have not been tested by the developers/maintainers of this package.
 
-- [M30 Series](https://www.axis.com/en-ca/products/axis-m30-series)
-- [M42 Series](https://www.axis.com/en-ca/products/axis-m42-series)
-- [Q62 Series](https://www.axis.com/en-ca/products/axis-q62-series)
-- [F Series](https://www.axis.com/en-ca/products/axis-f-series)
+If you have used this driver with a specific model of camera not listed below, please submit a PR so we can keep this
+list up-to-date.
+
+- [F Series](https://www.axis.com/products/axis-f-series)
+- [M30 Series](https://www.axis.com/products/axis-m30-series)
+- [P55 Series](https://www.axis.com/products/axis-p55-series)
+- [Q62 Series](https://www.axis.com/products/axis-q62-series)
+
 
 
 Camera Preparation
@@ -114,12 +118,13 @@ float32 focus
 float32 brightness
 float32 iris
 bool autofocus
+bool autoiris
 ```
 
 To write to the camera, use
 
 ```bash
-rostopic pub /camera_name/cmd axis_camera/Axis "{pan: 45.0, tilt: 20.0, zoom: 1000.0, focus: 0.0, brightness: 1.0, iris: 1.0, autofocus: true}" -1
+rostopic pub /camera_name/cmd axis_camera/Axis "{pan: 45.0, tilt: 20.0, zoom: 1000.0, focus: 0.0, brightness: 1.0, iris: 1.0, autofocus: true, autoiris: true}" -1
 ```
 
 All writable camera properties are set simultaneously.  It is recommended to read the camera's current state from

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ All writable camera properties are set simultaneously.  It is recommended to rea
 `tilt` and `zoom` fields as desired.  Failure to set the `brightness` field may result in a very dark image.
 
 `pan` and `tilt` are expressed in degrees (for ease of use with Axis' REST API) with positive tilt being upwards and
-positive pan being anticockwise.
+positive pan being clockwise.
 
 `zoom` is a value from 1 to 10000, with higher numbers indicating a narrower field of view.
 

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,26 @@
+Overview
+========
+
+This ROS_ package provides an `Axis network camera`_ driver, written
+in Python.
+
+ROS wiki documentation: `axis_camera`_.
+
+This driver is under active development.  Its ROS interfaces are
+relatively stable, but may still change.  
+
+There is no released code API.
+
+**Warning**::
+
+  The master branch normally contains code being tested for the next
+  ROS release.  It does not always work with previous ROS distributions.
+  Sometimes, it may not work at all.
+
+Each official release is tagged in the repository. The `change
+history`_ describes every version.
+
+.. _`Axis network camera`: http://www.axis.com/products/video/camera/index.htm
+.. _`change history`: https://github.com/clearpathrobotics/axis_camera/blob/master/CHANGELOG.rst
+.. _`axis_camera`: http://ros.org/wiki/axis_camera
+.. _ROS: http://ros.org

--- a/conf.py
+++ b/conf.py
@@ -44,8 +44,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'axis_camera'
-copyright = u'2012, Ryan Gariepy'
+project = 'axis_camera'
+copyright = '2012, Ryan Gariepy'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -187,8 +187,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'axis_camera.tex', u'ROS Axis camera driver.',
-   u'Ryan Gariepy', 'manual'),
+  ('index', 'axis_camera.tex', 'ROS Axis camera driver.',
+   'Ryan Gariepy', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -217,8 +217,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'axis_camera', u'ROS Python Axis camera driver.',
-     [u'Ryan Gariepy'], 1)
+    ('index', 'axis_camera', 'ROS Python Axis camera driver.',
+     ['Ryan Gariepy'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -231,8 +231,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'axis_camera', u'axis_camera Documentation',
-   u'Ryan Gariepy', 'axis_camera', 'ROS Axis camera driver.',
+  ('index', 'axis_camera', 'axis_camera Documentation',
+   'Ryan Gariepy', 'axis_camera', 'ROS Axis camera driver.',
    'Miscellaneous'),
 ]
 

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -4,6 +4,8 @@
   <arg name="enable_theora" default="0" />
   <arg name="enable_ptz" default="0" />
   <arg name="enable_ptz_teleop" default="0" />
+  <arg name="enable_ir" default="0" />
+  <arg name="enable_wiper" default="0" />
   <arg name="width" default="640" />
   <arg name="height" default="480" />
   <arg name="camera" default="1" />
@@ -13,6 +15,10 @@
     <param name="width" value="$(arg width)" />
     <param name="height" value="$(arg height)" />
     <param name="camera" value="$(arg camera)" />
+    <param name="frame_id" default="$(arg camera_name)" />
+    <param name="wiper" default="$(arg enable_wiper)" />
+    <param name="ir" default="$(arg enable_ir)" />
+
     <node pkg="axis_camera" type="axis.py" name="axis" />
     <node pkg="axis_camera" type="axis_ptz.py" name="axis_ptz" if="$(arg enable_ptz)" />
 

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -15,9 +15,9 @@
     <param name="width" value="$(arg width)" />
     <param name="height" value="$(arg height)" />
     <param name="camera" value="$(arg camera)" />
-    <param name="frame_id" default="$(arg camera_name)" />
-    <param name="wiper" default="$(arg enable_wiper)" />
-    <param name="ir" default="$(arg enable_ir)" />
+    <param name="frame_id" value="$(arg camera_name)" />
+    <param name="wiper" value="$(arg enable_wiper)" />
+    <param name="ir" value="$(arg enable_ir)" />
 
     <node pkg="axis_camera" type="axis.py" name="axis" />
     <node pkg="axis_camera" type="axis_ptz.py" name="axis_ptz" if="$(arg enable_ptz)" />

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -3,6 +3,7 @@
   <arg name="hostname" default="192.168.0.90" />
   <arg name="username" default="root" />
   <arg name="password" default="pass" />
+  <arg name="encrypt_password" default="false" />
 
   <arg name="enable_theora" default="0" />
   <arg name="enable_ptz" default="0" />
@@ -18,6 +19,7 @@
     <param name="hostname" value="$(arg hostname)" />
     <param name="username" value="$(arg username)" />
     <param name="password" value="$(arg password)" />
+    <param name="use_encrypted_password" value="$(arg encrypt_password)" />
     <param name="width" value="$(arg width)" />
     <param name="height" value="$(arg height)" />
     <param name="camera" value="$(arg camera)" />

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -2,7 +2,7 @@
   <arg name="camera_name" default="axis" />
   <arg name="hostname" default="192.168.0.90" />
   <arg name="username" default="root" />
-  <arg name="password" default="pass" />
+  <arg name="password" default="" />
   <arg name="encrypt_password" default="false" />
 
   <arg name="enable_theora" default="0" />

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -7,6 +7,7 @@
   <arg name="enable_theora" default="0" />
   <arg name="enable_ptz" default="0" />
   <arg name="enable_ptz_teleop" default="0" />
+  <arg name="enable_defog" default="0" />
   <arg name="enable_ir" default="0" />
   <arg name="enable_wiper" default="0" />
   <arg name="width" default="640" />
@@ -22,6 +23,7 @@
     <param name="camera" value="$(arg camera)" />
     <param name="frame_id" value="$(arg camera_name)" />
     <param name="wiper" value="$(arg enable_wiper)" />
+    <param name="defog" value="$(arg enable_defog)" />
     <param name="ir" value="$(arg enable_ir)" />
 
     <node pkg="axis_camera" type="axis.py" name="axis" />

--- a/launch/axis.launch
+++ b/launch/axis.launch
@@ -1,6 +1,9 @@
 <launch>
   <arg name="camera_name" default="axis" />
   <arg name="hostname" default="192.168.0.90" />
+  <arg name="username" default="root" />
+  <arg name="password" default="pass" />
+
   <arg name="enable_theora" default="0" />
   <arg name="enable_ptz" default="0" />
   <arg name="enable_ptz_teleop" default="0" />
@@ -12,6 +15,8 @@
 
   <group ns="$(arg camera_name)">
     <param name="hostname" value="$(arg hostname)" />
+    <param name="username" value="$(arg username)" />
+    <param name="password" value="$(arg password)" />
     <param name="width" value="$(arg width)" />
     <param name="height" value="$(arg height)" />
     <param name="camera" value="$(arg camera)" />

--- a/msg/Axis.msg
+++ b/msg/Axis.msg
@@ -5,3 +5,4 @@ float32 focus
 float32 brightness
 float32 iris
 bool autofocus
+bool autoiris

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Axis camera image driver. Based on:
 # https://code.ros.org/svn/wg-ros-pkg/branches/trunk_cturtle/sandbox/axis_camera

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Axis camera image driver. Based on:
 # https://code.ros.org/svn/wg-ros-pkg/branches/trunk_cturtle/sandbox/axis_camera

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -33,7 +33,7 @@ class StreamThread(threading.Thread):
 
     def formURL(self):
         self.url = 'http://%s/mjpg/video.mjpg' % self.axis.hostname
-        self.url += "?fps=0&resolution=%dx%d" % (self.axis.width,
+        self.url += "?fps=%d&resolution=%dx%d" % (self.axis.fps, self.axis.width,
                                                             self.axis.height)
 
         # support for Axis F34 multicamera switch
@@ -142,13 +142,14 @@ class StreamThread(threading.Thread):
         self.axis.caminfo_pub.publish(cimsg)
 
 class Axis:
-    def __init__(self, hostname, username, password, width, height, frame_id,
+    def __init__(self, hostname, username, password, width, height, fps, frame_id,
                  camera_info_url, use_encrypted_password, camera):
         self.hostname = hostname
         self.username = username
         self.password = password
         self.width = width
         self.height = height
+        self.fps = fps
         self.frame_id = frame_id
         self.camera_info_url = camera_info_url
         self.use_encrypted_password = use_encrypted_password
@@ -184,6 +185,7 @@ def main():
         'password': '',
         'width': 640,
         'height': 480,
+        'fps': 0,                         # frames per second (0 = camera default)
         'frame_id': 'axis_camera',
         'camera_info_url': '',
         'use_encrypted_password' : False,

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -164,7 +164,10 @@ class Axis:
             'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36',
             'From': f'http://{self.hostname}'
         }
-        self.http_auth = requests.auth.HTTPDigestAuth(self.username, self.password)
+        if self.use_encrypted_password:
+            self.http_auth = requests.auth.HTTPDigestAuth(self.username, self.password)
+        else:
+            self.http_auth = requests.auth.HTTPBasicAuth(self.username, self.password)
         self.http_timeout = (3, 5)
 
         # generate a valid camera name based on the hostname
@@ -176,7 +179,7 @@ class Axis:
         self.pub = rospy.Publisher("image_raw/compressed", CompressedImage, self, queue_size=1)
         self.caminfo_pub = rospy.Publisher("camera_info", CameraInfo, self, queue_size=1)
 
-        # The Axis Q6215 supports a night-vision mode with an active IR illuminator
+        # The Axis Q62 series supports a night-vision mode with an active IR illuminator
         # If this option is enabled, add the necessary services and topics
         if ir:
             self.ir_on = False
@@ -187,7 +190,7 @@ class Axis:
 
             self.handle_toggle_ir(SetBoolRequest(False))
 
-        # The Axis Q6215 is equipped with a wiper on the camera lens
+        # The Axis Q62 series is equipped with a wiper on the camera lens
         # If this option is enabled, add the necessary services and topics
         if wiper:
             self.wiper_on_time = datetime.datetime.utcnow()
@@ -199,7 +202,7 @@ class Axis:
 
             self.handle_toggle_wiper(SetBoolRequest(False))
 
-        # The Axis Q6215 is equipped with a defogger
+        # The Axis Q62 series is equipped with a defogger
         # If this option is enabled, add the necessary services and topics
         if defog:
             self.defog_on = False

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -199,25 +199,25 @@ class Axis:
     def handle_toggle_ir(self, req):
         """Turn the IR mode on/off (if supported)"""
         # TODO: figure out the URL endpoint to toggle the IR mode
-        pass
+        self.ir_on = req.data
 
     def ir_on_pub_thread_fn(self):
         """Publish whether the IR mode is on or off at 1Hz"""
         rate = rospy.Rate(1)
         while not rospy.is_shutdown():
-            self.ir_on_pub_thread.publish(Bool(self.ir_on))
+            self.ir_on_pub.publish(Bool(self.ir_on))
             rate.sleep()
 
     def handle_toggle_wiper(self, req):
         """Turn the wiper on/off (if supported)"""
         # TODO: figure out the URL endpoint to toggle the wiper
-        pass
+        self.wiper_on = req.data
 
     def wiper_on_pub_thread_fn(self):
         """Publish whether the wiper is running or not at 1Hz"""
         rate = rospy.Rate(1)
         while not rospy.is_shutdown():
-            self.wiper_on_pub_thread.publish(Bool(self.wiper_on))
+            self.wiper_on_pub.publish(Bool(self.wiper_on))
             rate.sleep()
 
 
@@ -238,6 +238,7 @@ def main():
         'ir': False,
         'wiper': False }
     args = updateArgs(arg_defaults)
+    rospy.logwarn(args)
     Axis(**args)
     rospy.spin()
 

--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -80,6 +80,7 @@ class StateThread(threading.Thread):
                     self.adjustForFlippedOrientation()
                 self.msg.tilt = float(self.cameraPosition['tilt'])
                 self.msg.zoom = float(self.cameraPosition['zoom'])
+                self.msg.brightness = float(self.cameraPosition['brightness'])
                 self.msg.iris = 0.0
                 if 'iris' in self.cameraPosition:
                     self.msg.iris = float(self.cameraPosition['iris'])
@@ -88,6 +89,8 @@ class StateThread(threading.Thread):
                     self.msg.focus = float(self.cameraPosition['focus'])
                 if 'autofocus' in self.cameraPosition:
                     self.msg.autofocus = (self.cameraPosition['autofocus'] == 'on')
+                if 'autoiris' in self.cameraPosition:
+                    self.msg.autoiris = (self.cameraPosition['autoiris'] == 'on')
                 self.axis.pub.publish(self.msg)
         except KeyError as e:
             rospy.logwarn("Camera not ready for polling its telemetry: " + repr(e.message))
@@ -257,7 +260,10 @@ class AxisPTZ:
             else:
                 self.cmdString += 'autofocus=off&continuousfocusmove=%d&' % \
                                                         (int(self.msg.focus))
-            self.cmdString += 'autoiris=on'
+            if self.msg.autoiris:
+                self.cmdString += 'autoiris=on'
+            else:
+                self.cmdString += 'autoiris=off'
         else: # position control:
             self.cmdString += 'pan=%d&tilt=%d&' % (self.msg.pan, self.msg.tilt)\
                         + 'zoom=%d&' % (int(self.msg.zoom)) \
@@ -267,7 +273,10 @@ class AxisPTZ:
             else:
                 self.cmdString += 'autofocus=off&focus=%d&' % \
                                                         (int(self.msg.focus))
-            self.cmdString += 'autoiris=on'
+            if self.msg.autoiris:
+                self.cmdString += 'autoiris=on'
+            else:
+                self.cmdString += 'autoiris=off'
 
     def mirrorCallback(self, msg):
         '''Command the camera with speed control or position control commands'''

--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Basic PTZ node, based on documentation here:
 #   http://www.axis.com/files/manuals/vapix_ptz_45621_en_1112.pdf

--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Basic PTZ node, based on documentation here:
 #   http://www.axis.com/files/manuals/vapix_ptz_45621_en_1112.pdf
@@ -47,6 +47,7 @@ class StateThread(threading.Thread):
                 body = response.read()
                 new_camera_position = dict()
                 for s in body.splitlines():
+                    s = s.decode('utf-8')
                     field_and_value = s.split('=', 2)
                     if len(field_and_value) == 2:
                         # On some PTZ cameras (AXIS 212 PTZ for example)

--- a/nodes/publish_axis_tf.py
+++ b/nodes/publish_axis_tf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import rospy
 import math

--- a/nodes/teleop.py
+++ b/nodes/teleop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from sensor_msgs.msg import Joy

--- a/nodes/teleop_speed_control.py
+++ b/nodes/teleop_speed_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from sensor_msgs.msg import Joy

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.4.3</version>
+  <version>0.4.2</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.4.2</version>
+  <version>0.4.3</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <run_depend>camera_info_manager_py</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>python3-requests</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <url type="bugtracker">https://github.com/ros-drivers/axis_camera/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <build_depend>camera_info_manager_py</build_depend>
   <build_depend>geometry_msgs</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    install_requires=['rospy', 'urllib2'],
+    install_requires=['rospy', 'urllib'],
     )
 
 setup(**d)

--- a/tests/view_axis.launch
+++ b/tests/view_axis.launch
@@ -18,9 +18,7 @@
   <arg name="password" default="" />
   <arg name="encrypt_password" default="false" />
 
-  <arg name="camera_info_url"
-       default="package://axis_camera/tests/default_calibration.yaml" />
-  <group ns="$(arg camera)">
+  <group ns="$(arg camera_name)">
 
     <node pkg="axis_camera" type="axis.py" name="axis">
       <param name="hostname" value="$(arg hostname)" />
@@ -29,7 +27,6 @@
       <param name="use_encrypted_password" value="$(arg encrypt_password)" />
       <param name="frame_id" value="$(arg camera_name)" />
       <param name="camera"   value="$(arg camera)" />
-      <param name="camera_info_url" value="$(arg camera_info_url)" />
     </node>
 
   <!-- Viewer window -->

--- a/tests/view_axis.launch
+++ b/tests/view_axis.launch
@@ -15,7 +15,8 @@
   <arg name="camera" default="1" />
   <arg name="hostname" default="192.168.0.90" />
   <arg name="username" default="root" />
-  <arg name="password" />
+  <arg name="password" default="" />
+  <arg name="encrypt_password" default="false" />
 
   <arg name="camera_info_url"
        default="package://axis_camera/tests/default_calibration.yaml" />
@@ -25,6 +26,7 @@
       <param name="hostname" value="$(arg hostname)" />
       <param name="username" value="$(arg username)" />
       <param name="password" value="$(arg password)" />
+      <param name="use_encrypted_password" value="$(arg encrypt_password)" />
       <param name="frame_id" value="$(arg camera_name)" />
       <param name="camera"   value="$(arg camera)" />
       <param name="camera_info_url" value="$(arg camera_info_url)" />


### PR DESCRIPTION
Big update that adds a lot of new features:

- Improved authentication support (should be possible to use the driver without enabling anonymous users)
- Partial rewrite of HTTP GET/POST calls using `requests`
- Add support for IR/Night-vision mode available on the Q62 Series cameras
- Add support for the defogger available on the Q62 Series cameras
- Add support for the lens wiper available on the Q62 Series cameras
- Improved documentation (usage examples, summary of topics/services, supported cameras)

Still undergoing some testing, but I think this should be ready to merge soon.