### PR TITLE
Wait until camera is online before connecting

### DIFF
--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -32,9 +32,9 @@ class StreamThread(threading.Thread):
 
         # ping syntax is different on Windows than Linux, so set the command accordingly
         if os.name == 'nt':
-            cmd = f"ping -W 5 -n 1 f{self.axis.hostname}".split()
+            cmd = f"ping -W 5 -n 1 {self.axis.hostname}".split()
         else:
-            cmd = f"ping -W 5 -c 1 f{self.axis.hostname}".split()
+            cmd = f"ping -W 5 -c 1 {self.axis.hostname}".split()
 
         rospy.loginfo(f"Waiting until {self.axis.hostname} is online...")
         host_alive = subprocess.call(cmd) == 0

--- a/nodes/axis.py
+++ b/nodes/axis.py
@@ -5,17 +5,19 @@
 # /axis.py
 #
 
-import threading
-import urllib.request, urllib.error, urllib.parse
-import requests, requests.auth
+import camera_info_manager
 import datetime
-import time
-
+import os
+import requests, requests.auth
 import rospy
+import subprocess
+import threading
+import time
+import urllib.request, urllib.error, urllib.parse
+
 from sensor_msgs.msg import CompressedImage, CameraInfo
 from std_msgs.msg import Bool
 from std_srvs.srv import SetBool, SetBoolRequest, SetBoolResponse
-import camera_info_manager
 
 class StreamThread(threading.Thread):
     def __init__(self, axis):
@@ -24,7 +26,28 @@ class StreamThread(threading.Thread):
         self.daemon = True
         self.timeoutSeconds = 2.5
 
+    def waitForHost(self):
+        '''Wait until the host is actually online before we try to contact it.
+        This reduces http related errors'''
+
+        # ping syntax is different on Windows than Linux, so set the command accordingly
+        if os.name == 'nt':
+            cmd = f"ping -W 5 -n 1 f{self.axis.hostname}".split()
+        else:
+            cmd = f"ping -W 5 -c 1 f{self.axis.hostname}".split()
+
+        rospy.loginfo(f"Waiting until {self.axis.hostname} is online...")
+        host_alive = subprocess.call(cmd) == 0
+        rate = rospy.Rate(1)
+        while not host_alive:
+            rate.sleep()
+            host_alive = subprocess.call(cmd) == 0
+
+        rospy.loginfo(f"{self.axis.hostname} is now online")
+
     def run(self):
+        self.waitForHost()
+
         while(True):
             self.stream()
 

--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -43,9 +43,9 @@ class StateThread(threading.Thread):
 
         # ping syntax is different on Windows than Linux, so set the command accordingly
         if os.name == 'nt':
-            cmd = f"ping -W 5 -n 1 f{self.axis.hostname}".split()
+            cmd = f"ping -W 5 -n 1 {self.axis.hostname}".split()
         else:
-            cmd = f"ping -W 5 -c 1 f{self.axis.hostname}".split()
+            cmd = f"ping -W 5 -c 1 {self.axis.hostname}".split()
 
         rospy.loginfo(f"Waiting until {self.axis.hostname} is online...")
         host_alive = subprocess.call(cmd) == 0

--- a/nodes/axis_ptz.py
+++ b/nodes/axis_ptz.py
@@ -115,6 +115,7 @@ class StateThread(threading.Thread):
                 if 'autoiris' in self.cameraPosition:
                     self.msg.autoiris = (self.cameraPosition['autoiris'] == 'on')
                 self.axis.pub.publish(self.msg)
+                self.cameraPosition = None  # This prevents us re-publishing the same state on-error
         except KeyError as e:
             rospy.logwarn("Camera not ready for polling its telemetry: " + repr(e.message))
 


### PR DESCRIPTION
Some cameras, e.g. the Q62 series, take a very long time to power on. This can cause http errors if the ROS node starts before the camera is ready.  This adds a simple ping check to make sure the camera is actually online before we try to connect to it.