### PR TITLE
Change default PS4 controller inputs

### DIFF
--- a/axis_camera/config/teleop_ps4.yaml
+++ b/axis_camera/config/teleop_ps4.yaml
@@ -44,26 +44,33 @@
 #    AXIS        Value
 # Left Horiz.      0
 # Left Vert.       1
-# Right Horiz.     2
-# Right Vert.      5
-#    L2            3
-#    R2            4
-# D-pad Horiz.     9
-# D-pad Vert.      10
-# Accel x          7
-# Accel y          6
-# Accel z          8
+# Right Horiz.     3
+# Right Vert.      4
+#    L2            2
+#    R2            5
+# D-pad Horiz.     6
+# D-pad Vert.      7
 
-# Hold X button to enable pan/tilt control
-# Hold circle button to enable zoom control
-button_enable_pan_tilt : 0
-button_enable_zoom     : 1
+# Optional: specify an enable button that must be held to allow pan/tilt/zoom controls
+button_enable_pan_tilt : -1
+button_enable_zoom     : -1
 
-# Left thumb stick for pan/tilt/zoom (depending on button above)
-axis_pan      : 0
-axis_tilt     : 1
-axis_zoom     : 1
-invert_tilt   : false
+# Right thumb stick to pan/tilt the camera
+axis_pan      : 3
+axis_tilt     : 4
+invert_tilt   : False
+
+# R2/L2 to zoom in/out
+axis_zoom_in: 5
+axis_zoom_out: 2
+
+# The analog triggers are normalled to +1 and move towards -1 as they are pressed
+# To convert them to the proper range we apply an offset and _then_ a multipicative scale
+# If we use e.g. a thumb stick instead, the offset should be 0 and the scale 1.0
+zoom_in_offset: -1
+zoom_out_offset: -1
+zoom_in_scale: -0.5
+zoom_out_scale: 0.5
 
 # Maximum pan/tilt/zoom velocities
 # max 2.61 rad/s rotation

--- a/axis_camera/config/teleop_ps4_alt.yaml
+++ b/axis_camera/config/teleop_ps4_alt.yaml
@@ -1,7 +1,7 @@
 # Teleop configuration for PS4 joystick using the x-pad configuration.
 #
-# This file uses the default order for PS4 controller axis enumeration:
-# L-horiz, L-vert, L-trig, R-horiz, R-vert, R-trig
+# This file uses the alternate order for PS4 controller axis enumeration:
+# L-horiz, L-vert, R-horiz, R-vert, L-trig, R-trig
 #
 #          L1                                       R1
 #          L2                                       R2
@@ -44,9 +44,9 @@
 #    AXIS        Value
 # Left Horiz.      0
 # Left Vert.       1
-# Right Horiz.     3
-# Right Vert.      4
-#    L2            2
+# Right Horiz.     2
+# Right Vert.      3
+#    L2            4
 #    R2            5
 # D-pad Horiz.     6
 # D-pad Vert.      7
@@ -56,13 +56,13 @@ button_enable_pan_tilt : -1
 button_enable_zoom     : -1
 
 # Right thumb stick to pan/tilt the camera
-axis_pan      : 3
-axis_tilt     : 4
+axis_pan      : 2
+axis_tilt     : 3
 invert_tilt   : False
 
 # R2/L2 to zoom in/out
 axis_zoom_in: 5
-axis_zoom_out: 2
+axis_zoom_out: 4
 
 # The analog triggers are normalled to +1 and move towards -1 as they are pressed
 # To convert them to the proper range we apply an offset and _then_ a multipicative scale

--- a/axis_camera/launch/axis.launch
+++ b/axis_camera/launch/axis.launch
@@ -16,6 +16,7 @@
 
   <arg name="enable_ptz_teleop" default="0" />
   <arg name="joy_topic" default="/bluetooth_teleop/joy" />
+  <arg name="joy_teleop_config" default="$(find axis_camera)/config/teleop_ps4.yaml" />
 
   <!-- desired FPS of the camera. 0=camera default -->
   <arg name="fps" default="0" />
@@ -45,7 +46,7 @@
 
     <group if="$(eval arg('enable_ptz_teleop') and arg('enable_ptz'))">
       <node pkg="axis_camera" type="axis_teleop_node" name="axis_teleop">
-        <rosparam command="load" file="$(find axis_camera)/config/teleop_ps4.yaml" />
+        <rosparam command="load" file="$(arg joy_teleop_config)" />
         <remap from="joy" to="$(arg joy_topic)" />
       </node>
     </group>

--- a/axis_camera/nodes/axis_teleop_node
+++ b/axis_camera/nodes/axis_teleop_node
@@ -25,8 +25,6 @@ scale_pan = 2.61
 scale_tilt = 2.61
 scale_zoom = 100
 
-dead_zone = 0.1
-
 class AxisPtzTeleopNode:
     def __init__(self):
         self.button_enable_pan_tilt = rospy.get_param("~button_enable_pan_tilt", button_enable_pan_tilt)
@@ -47,6 +45,8 @@ class AxisPtzTeleopNode:
         self.scale_tilt = rospy.get_param("~scale_tilt", scale_tilt)
         self.scale_zoom = rospy.get_param("~scale_zoom", scale_zoom)
 
+        self.last_cmd = Ptz()
+
     def start(self):
         self.cmd_pub = rospy.Publisher("cmd/velocity", Ptz, queue_size=1)
         self.joy_sub = rospy.Subscriber("joy", Joy, self.joy_callback)
@@ -56,22 +56,21 @@ class AxisPtzTeleopNode:
         tilt = 0
         zoom = 0
         if self.button_enable_pan_tilt < 0 or msg.buttons[self.button_enable_pan_tilt]:
-            if abs(msg.axes[self.axis_pan]) >= dead_zone:
-                pan = msg.axes[self.axis_pan] * -self.scale_pan
-            if abs(msg.axes[self.axis_tilt]) >= dead_zone:
-                tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
+            pan = msg.axes[self.axis_pan] * -self.scale_pan
+            tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
 
         if self.button_enable_zoom < 0 or msg.buttons[self.button_enable_zoom]:
             zoom_in_amt = (msg.axes[self.axis_zoom_in] + self.zoom_in_offset) * self.zoom_in_scale
             zoom_out_amt = (msg.axes[self.axis_zoom_out] + self.zoom_out_offset) * self.zoom_out_scale
             zoom = (zoom_in_amt + zoom_out_amt) * self.scale_zoom
 
-        if pan != 0 or tilt != 0 or zoom != 0:
+        if pan != self.last_cmd.pan or tilt != self.last_cmd.tilt or zoom != self.last_cmd.zoom:
             cmd = Ptz()
             cmd.pan = pan
             cmd.tilt = tilt
             cmd.zoom = zoom
             self.cmd_pub.publish(cmd)
+            self.last_cmd = cmd
 
 def main():
     rospy.init_node("axis_teleop_node")

--- a/axis_camera/nodes/axis_teleop_node
+++ b/axis_camera/nodes/axis_teleop_node
@@ -25,6 +25,8 @@ scale_pan = 2.61
 scale_tilt = 2.61
 scale_zoom = 100
 
+dead_zone = 0.1
+
 class AxisPtzTeleopNode:
     def __init__(self):
         self.button_enable_pan_tilt = rospy.get_param("~button_enable_pan_tilt", button_enable_pan_tilt)
@@ -54,8 +56,10 @@ class AxisPtzTeleopNode:
         tilt = 0
         zoom = 0
         if self.button_enable_pan_tilt < 0 or msg.buttons[self.button_enable_pan_tilt]:
-            pan = msg.axes[self.axis_pan] * self.scale_pan
-            tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
+            if abs(msg.axes[self.axis_pan]) >= dead_zone:
+                pan = msg.axes[self.axis_pan] * -self.scale_pan
+            if abs(msg.axes[self.axis_tilt]) >= dead_zone:
+                tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
 
         if self.button_enable_zoom < 0 or msg.buttons[self.button_enable_zoom]:
             zoom_in_amt = (msg.axes[self.axis_zoom_in] + self.zoom_in_offset) * self.zoom_in_scale

--- a/axis_camera/nodes/axis_teleop_node
+++ b/axis_camera/nodes/axis_teleop_node
@@ -6,13 +6,19 @@ import rospy
 from sensor_msgs.msg import Joy
 from axis_msgs.msg import Ptz
 
-button_enable_pan_tilt = 0
-button_enable_zoom = 1
+button_enable_pan_tilt = -1
+button_enable_zoom = -1
 
-axis_pan = 0
-axis_tilt = 1
-axis_zoom = 1
+axis_pan = 3
+axis_tilt = 4
 invert_tilt = False
+
+axis_zoom_in = 5
+axis_zoom_out = 2
+zoom_in_offset = -1
+zoom_out_offset = -1
+zoom_in_scale = -0.5
+zoom_out_scale = 0.5
 
 # max pan/tilt speed of 2.61 rad/2
 scale_pan = 2.61
@@ -23,10 +29,18 @@ class AxisPtzTeleopNode:
     def __init__(self):
         self.button_enable_pan_tilt = rospy.get_param("~button_enable_pan_tilt", button_enable_pan_tilt)
         self.button_enable_zoom = rospy.get_param("~button_enable_zoom", button_enable_zoom)
+
         self.axis_pan = rospy.get_param("~axis_pan", axis_pan)
         self.axis_tilt = rospy.get_param("~axis_tilt", axis_tilt)
-        self.axis_zoom = rospy.get_param("~axis_zoom", axis_zoom)
         self.invert_tilt = rospy.get_param("~invert_tilt", invert_tilt)
+
+        self.axis_zoom_in = rospy.get_param("~axis_zoom_in", axis_zoom_in)
+        self.axis_zoom_out = rospy.get_param("~axis_zoom_out", axis_zoom_out)
+        self.zoom_in_offset = rospy.get_param("~zoom_in_offset", zoom_in_offset)
+        self.zoom_out_offset = rospy.get_param("~zoom_out_offset", zoom_out_offset)
+        self.zoom_in_scale = rospy.get_param("~zoom_in_scale", zoom_in_scale)
+        self.zoom_out_scale = rospy.get_param("~zoom_out_scale", zoom_out_scale)
+
         self.scale_pan = rospy.get_param("~scale_pan", scale_pan)
         self.scale_tilt = rospy.get_param("~scale_tilt", scale_tilt)
         self.scale_zoom = rospy.get_param("~scale_zoom", scale_zoom)
@@ -36,15 +50,23 @@ class AxisPtzTeleopNode:
         self.joy_sub = rospy.Subscriber("joy", Joy, self.joy_callback)
 
     def joy_callback(self, msg):
-        if msg.buttons[self.button_enable_pan_tilt] or msg.buttons[self.button_enable_zoom]:
+        pan = 0
+        tilt = 0
+        zoom = 0
+        if self.button_enable_pan_tilt < 0 or msg.buttons[self.button_enable_pan_tilt]:
+            pan = msg.axes[self.axis_pan] * self.scale_pan
+            tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
+
+        if self.button_enable_zoom < 0 or msg.buttons[self.button_enable_zoom]:
+            zoom_in_amt = (msg.axes[self.axis_zoom_in] + self.zoom_in_offset) * self.zoom_in_scale
+            zoom_out_amt = (msg.axes[self.axis_zoom_out] + self.zoom_out_offset) * self.zoom_out_scale
+            zoom = (zoom_in_amt + zoom_out_amt) * self.scale_zoom
+
+        if pan != 0 or tilt != 0 or zoom != 0:
             cmd = Ptz()
-            if msg.buttons[self.button_enable_pan_tilt]:
-                cmd.pan = -msg.axes[self.axis_pan] * self.scale_pan   # invert the pan direction
-                cmd.tilt = msg.axes[self.axis_tilt] * self.scale_tilt * (-1 if self.invert_tilt else 1)
-
-            if msg.buttons[self.button_enable_zoom]:
-                cmd.zoom = msg.axes[self.axis_zoom] * self.scale_zoom
-
+            cmd.pan = pan
+            cmd.tilt = tilt
+            cmd.zoom = zoom
             self.cmd_pub.publish(cmd)
 
 def main():


### PR DESCRIPTION
Refactor the teleop controls to make enable buttons optional, change the defaults to use the right thumb stick for pan/tilt and right/left analog triggers for zoom in/out