### PR TITLE
Incorrect struct access in velocity action

### DIFF
--- a/axis_camera/axis_camera/axis_ptz.py
+++ b/axis_camera/axis_camera/axis_ptz.py
@@ -398,9 +398,9 @@ class AxisPtz:
         result.success = True
 
         fb = PtzMove.Feedback()
-        fb.ptz_remaining.pan = clamp(goal_handle.request.pan, -self.max_pan_speed, self.max_pan_speed)  # noqa: E501
-        fb.ptz_remaining.tilt = clamp(goal_handle.request.tilt, -self.max_tilt_speed, self.max_tilt_speed)  # noqa: E501
-        fb.ptz_remaining.zoom = clamp(goal_handle.request.zoom, -1.0, 1.0)
+        fb.ptz_remaining.pan = clamp(goal_handle.request.ptz.pan, -self.max_pan_speed, self.max_pan_speed)  # noqa: E501
+        fb.ptz_remaining.tilt = clamp(goal_handle.request.ptz.tilt, -self.max_tilt_speed, self.max_tilt_speed)  # noqa: E501
+        fb.ptz_remaining.zoom = clamp(goal_handle.request.ptz.zoom, -1.0, 1.0)
 
         self.ptz_state.mode = PtzState.MODE_VELOCITY
         if not self.send_velocity_command(cmd_pan, cmd_tilt, cmd_zoom):


### PR DESCRIPTION
Sending a velocity command:

`ros2 action send_goal /ptz_camera_node/move_ptz/velocity ptz_action_server_msgs/action/PtzMove "{ptz: {pan: 0.0, tilt: 0.0, zoom: 0.0}}"`

gives:

```
Waiting for an action server to become available...
Sending goal:
     ptz:
  pan: 0.0
  tilt: 0.0
  zoom: 0.0
Goal accepted with ID: 0f8c388c97db460788b378b3a363fcd9
Result:
    success: false
message: ''
Goal finished with status: ABORTED
```

monitoring the rosout gives:
```
ros2 topic echo /rosout | grep -C 5 cam
---
stamp:
  sec: 1761752098
  nanosec: 748413472
level: 40
name: camera_zoom.camera_zoom_node.action_server
msg: 'Error raised in execute callback: ''PtzMove_Goal'' object has no attribute ''pan'''
file: /opt/ros/jazzy/lib/python3.12/site-packages/rclpy/action/server.py
function: _execute_goal
line: 340
---
stamp:
  sec: 1761752098
  nanosec: 749811604
level: 30
name: camera_zoom.camera_zoom_node.action_server
msg: 'Goal state not set, assuming aborted. Goal ID: [ 91 119 192  76 152  73  79 151 151 249 226 165 239 166 235 107]'
file: /opt/ros/jazzy/lib/python3.12/site-packages/rclpy/action/server.py
function: _execute_goal
line: 345
---
```

I tracked down the error to these lines (goal_handle.request.pan, goal_handle.request.tilt, goal_handle.request.zoom): 
https://github.com/ros-drivers/axis_camera/blob/2a0b1b32a844ed6769d3188a5a203aab8f2a8aa6/axis_camera/axis_camera/axis_ptz.py#L401-L403

And it seems to incorrectly unpack those variables, it should be:

fb.ptz_remaining.pan = clamp(goal_handle.request.**ptz**.pan, -self.max_pan_speed, self.max_pan_speed)  # noqa: E501
fb.ptz_remaining.tilt = clamp(goal_handle.request.**ptz**.tilt, -self.max_tilt_speed, self.max_tilt_speed)  # noqa: E501
fb.ptz_remaining.zoom = clamp(goal_handle.request.**ptz**.zoom, -1.0, 1.0)
